### PR TITLE
compiles all except some of the tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,17 @@ set(CMAKE_CXX_STANDARD 11)
 if (WIN32)
   add_definitions(/bigobj)
   #set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+  #this must be disabled unless the previous option (CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS) is enabled
+  option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+else()
+  option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 endif (WIN32)
 
 
 OPTION(BUILD_USE_SOLUTION_FOLDERS "Enable grouping of projects in VS" ON) 
 SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ${BUILD_USE_SOLUTION_FOLDERS}) 
 
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 option(HAVE_BIN          "Build the fst binaries" ON)
 option(HAVE_SCRIPT       "Build the fstscript" ON)
 option(HAVE_COMPACT      "Build compact" ON)

--- a/src/include/fst/set-weight.h
+++ b/src/include/fst/set-weight.h
@@ -193,7 +193,7 @@ class SetWeightIterator {
   const Label &first_;
   const decltype(Weight::rest_) &rest_;
   bool init_;  // In the initialized state?
-  typename decltype(Weight::rest_)::const_iterator iter_;
+  typename std::remove_reference<decltype(Weight::rest_)>::type::const_iterator iter_;
 };
 
 

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -51,7 +51,7 @@ add_library(fstscript
   verify.cc
   ${HEADER_FILES}
 )
-target_link_libraries(fstscript fst)
+target_link_libraries(fstscript PRIVATE fst)
 
 set_target_properties(fstscript PROPERTIES
   SOVERSION "6"

--- a/src/script/shortest-path.cc
+++ b/src/script/shortest-path.cc
@@ -19,8 +19,8 @@ void ShortestPath(const FstClass &ifst, MutableFstClass *ofst,
 }
 
 REGISTER_FST_OPERATION(ShortestPath, StdArc, ShortestPathArgs);
-//REGISTER_FST_OPERATION(ShortestPath, LogArc, ShortestPathArgs);
-//REGISTER_FST_OPERATION(ShortestPath, Log64Arc, ShortestPathArgs);
+REGISTER_FST_OPERATION(ShortestPath, LogArc, ShortestPathArgs);
+REGISTER_FST_OPERATION(ShortestPath, Log64Arc, ShortestPathArgs);
 
 }  // namespace script
 }  // namespace fst

--- a/src/script/shortest-path.cc
+++ b/src/script/shortest-path.cc
@@ -19,8 +19,8 @@ void ShortestPath(const FstClass &ifst, MutableFstClass *ofst,
 }
 
 REGISTER_FST_OPERATION(ShortestPath, StdArc, ShortestPathArgs);
-REGISTER_FST_OPERATION(ShortestPath, LogArc, ShortestPathArgs);
-REGISTER_FST_OPERATION(ShortestPath, Log64Arc, ShortestPathArgs);
+//REGISTER_FST_OPERATION(ShortestPath, LogArc, ShortestPathArgs);
+//REGISTER_FST_OPERATION(ShortestPath, Log64Arc, ShortestPathArgs);
 
 }  // namespace script
 }  // namespace fst


### PR DESCRIPTION
The tests algo_test_log and algo_test_power does not compile because:
```
7>C:\Users\jtrmal\Documents\openfst\src\include\fst/shortest-path.h(151): error C2338: Weight must have path property.
7>C:\Users\jtrmal\Documents\openfst\src\include\fst/shortest-path.h(429): note: see reference to function template instantiation 'bool fst::internal::SingleShortestPath<fst::LogArc,fst::AutoQueue<StateId>,fst::AnyArcFilter<Arc>>(const fst::Fst<fst::LogArc> &,std::vector<fst::LogWeightTpl<float>,std::allocator<_Ty>> *,const fst::ShortestPathOptions<Arc,fst::AutoQueue<StateId>,fst::AnyArcFilter<Arc>> &,fst::ArcTpl<fst::LogWeight>::StateId *,std::vector<std::pair<int,::size_t>,std::allocator<std::pair<int,::size_t>>> *)' being compiled
```
that also relates my changes src/script/shortest-path.cc in this PR (had to comment it out, as it was causing the same static_assert failure). I'm thinking if this is related to our changes .w.r.t. enable_if.

Another error is when compiling the test weight_test (weights_test.cc):
```
1>C:\Users\jtrmal\Documents\openfst\src\include\fst/set-weight.h(197): error C3646: 'iter_': unknown override specifier
1>C:\Users\jtrmal\Documents\openfst\src\include\fst/set-weight.h(198): note: see reference to class template instantiation 'fst::SetWeightIterator<SetWeight_>' being compiled
```