### PR TITLE
Some MsBuild-fu to compile all binaries in a single project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; EditorConfig to support per-solution formatting.
+; Use the EditorConfig VS add-in to make this work before VS 2017
+
+; This is the default for the codeline.
+root = true
+
+[*]
+charset = utf-8  ; Remove the pesky BOM from files.
+trim_trailing_whitespace = true
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Win32/
 x64/
 Debug/
 Release/
+obj/
+/bin/
+*.binlog
 *proj.user
 /cmake
 /cmake64

--- a/openfst.sln
+++ b/openfst.sln
@@ -1,19 +1,30 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfst", "src\lib\libfst.vcxproj", "{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{F14A9AF0-0D79-4553-AA8E-B3905A9B6431}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Control and build files", "Control and build files", "{F14A9AF0-0D79-4553-AA8E-B3905A9B6431}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		src\openfst-multibin.targets = src\openfst-multibin.targets
 		src\openfst.props = src\openfst.props
 		src\openfst.targets = src\openfst.targets
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfstscript", "src\script\libfstscript.vcxproj", "{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bin", "src\bin\bin.vcxproj", "{84657A19-CAF2-49E8-8DB3-A428C19F460D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6} = {111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "!! READ ME BEFORE BUILD !!", "!! READ ME BEFORE BUILD !!", "{3BAF0BB0-34BF-4E28-BC17-A80D7CF4130F}"
+	ProjectSection(SolutionItems) = preProject
+		src\openfst.user.props = src\openfst.user.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +50,14 @@ Global
 		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x64.Build.0 = Release|x64
 		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x86.ActiveCfg = Release|Win32
 		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x86.Build.0 = Release|Win32
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Debug|x64.ActiveCfg = Debug|x64
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Debug|x64.Build.0 = Debug|x64
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Debug|x86.ActiveCfg = Debug|Win32
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Debug|x86.Build.0 = Debug|Win32
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Release|x64.ActiveCfg = Release|x64
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Release|x64.Build.0 = Release|x64
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Release|x86.ActiveCfg = Release|Win32
+		{84657A19-CAF2-49E8-8DB3-A428C19F460D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/openfst.sln
+++ b/openfst.sln
@@ -1,9 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2024
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfst", "src\lib\libfst.vcxproj", "{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{F14A9AF0-0D79-4553-AA8E-B3905A9B6431}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		src\openfst.props = src\openfst.props
+		src\openfst.targets = src\openfst.targets
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfstscript", "src\script\libfstscript.vcxproj", "{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +31,19 @@ Global
 		{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}.Release|x64.Build.0 = Release|x64
 		{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}.Release|x86.ActiveCfg = Release|Win32
 		{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}.Release|x86.Build.0 = Release|Win32
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Debug|x64.ActiveCfg = Debug|x64
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Debug|x64.Build.0 = Debug|x64
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Debug|x86.ActiveCfg = Debug|Win32
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Debug|x86.Build.0 = Debug|Win32
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x64.ActiveCfg = Release|x64
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x64.Build.0 = Release|x64
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x86.ActiveCfg = Release|Win32
+		{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {14CFFA93-2ED0-43D3-A3E9-5203D4CB19BF}
 	EndGlobalSection
 EndGlobal

--- a/src/bin/bin.vcxproj
+++ b/src/bin/bin.vcxproj
@@ -1,0 +1,27 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+        Need ConfigurationType set before importing openfst.props!
+   -->
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{84657A19-CAF2-49E8-8DB3-A428C19F460D}</ProjectGuid>
+    <ConfigurationType>Application</ConfigurationType>
+    <MultiBin>true</MultiBin>
+  </PropertyGroup>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Import Project="../openfst.props" />
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <ItemGroup>
+    <ClCompile Include="*.cc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\lib\libfst.vcxproj">
+      <Project>{de80efec-9ed9-4631-bd96-8568c31ed26d}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\script\libfstscript.vcxproj">
+      <Project>{111f46ed-da1f-469b-b912-ba2acc2ff8e6}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Import Project="../openfst.targets" />
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+</Project>

--- a/src/lib/libfst.vcxproj
+++ b/src/lib/libfst.vcxproj
@@ -1,23 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+        Need ConfigurationType set before importing openfst.props!
+   -->
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}</ProjectGuid>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Import Project="../openfst.props" />
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
   <ItemGroup>
     <ClCompile Include="compat.cc" />
     <ClCompile Include="flags.cc" />
@@ -135,137 +127,7 @@
     <ClInclude Include="..\include\fst\visit.h" />
     <ClInclude Include="..\include\fst\weight.h" />
   </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <ProjectGuid>{DE80EFEC-9ED9-4631-BD96-8568C31ED26D}</ProjectGuid>
-    <Keyword>Win32Proj</Keyword>
-    <RootNamespace>fst</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <ProjectName>libfst</ProjectName>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4018;4099;4244;4267;4291;4305;4396;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <MinimalRebuild>false</MinimalRebuild>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4018;4099;4244;4267;4291;4305;4396;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
-      <MinimalRebuild>false</MinimalRebuild>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4018;4099;4244;4267;4291;4305;4396;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4018;4099;4244;4267;4291;4305;4396;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <DebugInformationFormat>OldStyle</DebugInformationFormat>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-    </Link>
-  </ItemDefinitionGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Import Project="../openfst.targets" />
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 </Project>

--- a/src/openfst-multibin.targets
+++ b/src/openfst-multibin.targets
@@ -1,0 +1,37 @@
+<!--  This file is imported only in a multi-bin outer project. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="_SelectSources">
+    <ItemGroup>
+      <!-- Force batching on %(Identity) -->
+      <ClCompile Condition=" '%(Identity)' != '' ">
+        <!-- Temporarily add '/' (just a character never found in %(Filename)) to the end to
+             strip off only the trailing "-main", not in the middle, and then trim it off. -->
+        <_ProjectName>@(ClCompile->'%(Filename)/'->Replace('-main/','')->TrimEnd('/'))</_ProjectName>
+      </ClCompile>
+      <!-- This implicitly batches on %(ClCompile._ProjectName), i.e. per target binary. -->
+      <Subprojects Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>ProjectName=%(ClCompile._ProjectName);OnlySources=@(ClCompile)</AdditionalProperties>
+      </Subprojects>
+    </ItemGroup>
+  </Target>
+
+  <!-- ResolveReferences may decide to build referenced lib projects if these are
+       not up to date, and we want it done before building binaries in parallel. -->
+  <Target Name="Build" DependsOnTargets="_SelectSources;ResolveReferences">
+    <MSBuild Projects="@(Subprojects)" Targets="Build" BuildInParallel="$(BuildInParallel)"
+             Properties='Platform=$(Platform);Configuration=$(Configuration)' />
+  </Target>
+
+  <Target Name="Clean" DependsOnTargets="_SelectSources">
+    <MSBuild Projects="@(Subprojects)" Targets="Clean" BuildInParallel="$(BuildInParallel)"
+             Properties='Platform=$(Platform);Configuration=$(Configuration)' />
+  </Target>
+
+  <Target Name="Rebuild" DependsOnTargets="_SelectSources;Clean;Build" />
+
+  <Target Name="LibLinkOnly">
+    <Error Text="Sorry, 'Project Only/Link Only this project' IDE command is unsupported in a multi-binary project." />
+  </Target>
+
+</Project>

--- a/src/openfst.props
+++ b/src/openfst.props
@@ -18,7 +18,7 @@
     </ProjectConfiguration>
   </ItemGroup>
 
-  <!-- Guess the solution dir if not set to enable consistent msbuild of individual projects. -->
+  <!-- Guess the solution dir if not set, to enable consistent command-line msbuild of individual projects. -->
   <PropertyGroup Condition=" '$(SolutionDir)' == '' ">
     <_SolutionDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), openfst.sln))</_SolutionDir>
     <_SolutionDir Condition=" '$(_SolutionDir)' == '' ">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory).."))</_SolutionDir>
@@ -26,10 +26,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProjectName>$(MSBuildProjectName)</ProjectName>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">8.1</WindowsTargetPlatformVersion>
     <PlatformToolset Condition=" '$(PlatformToolset)' == '' ">v141</PlatformToolset>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -44,12 +43,15 @@
   <PropertyGroup>
     <_TargetSubdir Condition=" '$(ConfigurationType)' == 'StaticLibrary' ">lib</_TargetSubdir>
     <_TargetSubdir Condition=" '$(ConfigurationType)' != 'StaticLibrary' ">bin</_TargetSubdir>
-    <OutDir>$(SolutionDir)bin\$(PlatformTarget)\$(Configuration)\$(_TargetSubdir)\</OutDir>
+    <OutDir>$(SolutionDir)build_output\$(PlatformTarget)\$(Configuration)\$(_TargetSubdir)\</OutDir>
     <IntDir>obj\$(PlatformTarget)\$(Configuration)\</IntDir>
   </PropertyGroup>
 
+  <Import Project="openfst.user.props" Condition="Exists('openfst.user.props')" />
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
+          Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
 
   <ItemDefinitionGroup>
     <!-- Most debug/release defaults set by UseDebugLibraries and WholeProgramOptimization are good. -->
@@ -63,11 +65,13 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <DisableSpecificWarnings>4018;4099;4244;4267;4291;4305;4396;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <EnableEnhancedInstructionSet>$(EnableEnhancedInstructionSet)</EnableEnhancedInstructionSet>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MinimalRebuild>false</MinimalRebuild>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>

--- a/src/openfst.props
+++ b/src/openfst.props
@@ -76,9 +76,15 @@
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <EnableCOMDATFolding Condition=" '$(Configuration)' == 'Release' ">true</EnableCOMDATFolding>
-      <OptimizeReferences  Condition=" '$(Configuration)' == 'Release' ">true</OptimizeReferences>
       <SubSystem>Console</SubSystem>
+    </Link>
+    <Link Condition=" '$(Configuration)' == 'Release' ">
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <!-- WholeProgramOptimization = true sets /LTCG:incremental. This is good
+           for development, when rebuild happens often, but not a correct setting
+           when sources are not often modified; use just /LTCG. -->
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
 

--- a/src/openfst.props
+++ b/src/openfst.props
@@ -1,0 +1,81 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <!-- Guess the solution dir if not set to enable consistent msbuild of individual projects. -->
+  <PropertyGroup Condition=" '$(SolutionDir)' == '' ">
+    <_SolutionDir>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), openfst.sln))</_SolutionDir>
+    <_SolutionDir Condition=" '$(_SolutionDir)' == '' ">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory).."))</_SolutionDir>
+    <SolutionDir  Condition=" '$(_SolutionDir)' != '' ">$(_SolutionDir)\</SolutionDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProjectName>$(MSBuildProjectName)</ProjectName>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">8.1</WindowsTargetPlatformVersion>
+    <PlatformToolset Condition=" '$(PlatformToolset)' == '' ">v141</PlatformToolset>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup>
+    <UseDebugLibraries Condition=" '$(Configuration)' == 'Debug' ">true</UseDebugLibraries>
+    <WholeProgramOptimization Condition=" '$(Configuration)' == 'Release' ">true</WholeProgramOptimization>
+  </PropertyGroup>
+
+  <!-- Use $(PlatformTarget) which is x86/ and x64/. Win32/ is historic
+       and weird (x64 is also technically Win32, it's the API name). -->
+  <PropertyGroup>
+    <_TargetSubdir Condition=" '$(ConfigurationType)' == 'StaticLibrary' ">lib</_TargetSubdir>
+    <_TargetSubdir Condition=" '$(ConfigurationType)' != 'StaticLibrary' ">bin</_TargetSubdir>
+    <OutDir>$(SolutionDir)bin\$(PlatformTarget)\$(Configuration)\$(_TargetSubdir)\</OutDir>
+    <IntDir>obj\$(PlatformTarget)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+
+  <ItemDefinitionGroup>
+    <!-- Most debug/release defaults set by UseDebugLibraries and WholeProgramOptimization are good. -->
+    <ClCompile>
+      <PreprocessorDefinitions Condition=" '$(Configuration)' == 'Debug' "  >_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition=" '$(Configuration)' == 'Release' ">NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4099;4244;4267;4291;4305;4396;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding Condition=" '$(Configuration)' == 'Release' ">true</EnableCOMDATFolding>
+      <OptimizeReferences  Condition=" '$(Configuration)' == 'Release' ">true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+
+</Project>

--- a/src/openfst.targets
+++ b/src/openfst.targets
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+
+</Project>

--- a/src/openfst.targets
+++ b/src/openfst.targets
@@ -1,5 +1,35 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" InitialTargets="_SelectOnlySources">
+
+  <PropertyGroup>
+    <!-- Keep separate tlog in each multi-bin subproject
+        (all projects, in fact, it does not hurt). Needs a trailing '\'. -->
+    <TLogLocation>$(IntDir)$(ProjectName).tlog\</TLogLocation>
+    <!-- Intentionally sharing, handled carefully. Quench the warning. -->
+    <IgnoreWarnIntDirSharingDetected Condition=" '$(MultiBin)' == 'true' ">true</IgnoreWarnIntDirSharingDetected>
+  </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+
+  <ItemDefinitionGroup>
+    <ProjectReference>
+      <!-- Do not propagate to dependent projects the properties that
+           we set on recursive invocation. -->
+      <GlobalPropertiesToRemove>ProjectName;OnlySources</GlobalPropertiesToRemove>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
+  <!-- In an inner build only, shrink down the ClCompile collection to those
+       passed in the OnlySources property. No harm doing this as early as
+       possible, so register this as InitialTarget. -->
+  <Target Name="_SelectOnlySources" Condition=" '$(MultiBin)' == 'true' and '$(DesignTimeBuild)' != 'true' ">
+    <ItemGroup Condition=" '$(OnlySources)' != '' ">
+      <_OnlySources Include="$(OnlySources)" />
+      <ClCompile Remove="@(ClCompile)" Condition="'%(Identity)' != '@(_OnlySources)'" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Override Build, Clean, Rebuild and certain IDE targets in a multi-bin outer build. -->
+  <Import Project="openfst-multibin.targets"
+          Condition=" '$(MultiBin)' == 'true' and '$(DesignTimeBuild)' != 'true' and '$(OnlySources)' == '' "/>
 
 </Project>

--- a/src/openfst.user.props
+++ b/src/openfst.user.props
@@ -1,0 +1,74 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!--
+    User settings, to simplify setup. The names and values of make variables
+    used by MsBuild scripts are not obvious, so I thought it would be easier
+    if the list of user choices in available in a single file.
+
+    All settings are disabled by default. Enable any of them by removing the
+    'Condition="false"' part.
+
+    You can instead specify these values in MsBuild command line. For example,
+    you can put the following command into a build.cmd file:
+
+    msbuild openfst.sln -v:m -m -t:Build ^
+              -p:Platform=x64 ^
+              -p:Configuration=Release ^
+              -p:PlatformToolset=v141 ^
+              -p:WindowsTargetPlatformVersion=10.0.16299.0 ^
+              -p:EnableEnhancedInstructionSet=AdvancedVectorExtensions
+-->
+
+  <!-- Toolset (default v141). Other compilers (Intel C++) may be specified. -->
+  <PropertyGroup>
+    <!-- v140 = 14.0, comes with VS14 aka VS 2015 -->
+    <PlatformToolset Condition="false" >v140</PlatformToolset>
+    <!-- v141 = 14.1, comes with VS15 aka VS 2017. This is the default. -->
+    <PlatformToolset Condition="false" >v141</PlatformToolset>
+  </PropertyGroup>
+
+  <!-- SDK version (default: toolset's default, likely 8.1). Note that v141 has
+       8.1 as the default SDK, but that SDK may not be installed with VS 2017
+       default C++ workload. If you get an message "MSB8036: The Windows SDK
+       version 8.1 was not found", check if you have any of Window 10 SDK
+       versions.
+
+       Run "x{86,64} Native Tools Command Prompt for VS 201{5,7}" from the
+       Start Menu, and type "set WindowsSDKVersion". The value of the
+       environment variable shows the installed version of the Windows 10 SDK.
+
+       You can also look for the versions in subdirectories of the folder
+       %ProgramFiles(x86)%\Windows Kits\10\DesignTime\CommonConfiguration\Neutral\UAP
+       (assuming the default install location for Windows SDK).
+
+       I am including a (possibly incomplete) list of released Windows 10 SDK
+       versions (any one would work, as long as you have it installed). -->
+  <PropertyGroup>
+    <!-- Windows 10 Fall Creators Update  -->
+    <WindowsTargetPlatformVersion Condition="false" >10.0.16299.0</WindowsTargetPlatformVersion>
+    <!-- Windows 10 Creators Update -->
+    <WindowsTargetPlatformVersion Condition="false" >10.0.15063.0</WindowsTargetPlatformVersion>
+    <!-- Windows 10 Anniversary Edition -->
+    <WindowsTargetPlatformVersion Condition="false" >10.0.14393.0</WindowsTargetPlatformVersion>
+    <!-- Windows 10 November 2015 SDK update-->
+    <WindowsTargetPlatformVersion Condition="false" >10.0.10586.0</WindowsTargetPlatformVersion>
+    <!-- Windows 10 original SDK, can have either of the two versions below:  -->
+    <WindowsTargetPlatformVersion Condition="false" >10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="false" >10.0.26624.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+
+  <!-- Enhanced instruction set (default SSE2, I believe).
+       NOTE: In kkm's experience, AVX helps the performance a little
+       (few % at most), AVX2 does not improve performance. YMMV.
+
+       Currently, there is no MS c2 codegen for AVX512 instructions.
+
+       Note: cl 32-bit compiler likely does not support AVX/AVX2. -->
+  <PropertyGroup>
+    <!-- AVX -->
+    <EnableEnhancedInstructionSet Condition="false" >AdvancedVectorExtensions</EnableEnhancedInstructionSet>
+
+    <!-- AVX2 -->
+    <EnableEnhancedInstructionSet Condition="false" >AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
+  </PropertyGroup>
+
+</Project>

--- a/src/script/libfstscript.vcxproj
+++ b/src/script/libfstscript.vcxproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+        Need ConfigurationType set before importing openfst.props!
+   -->
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{111F46ED-DA1F-469B-B912-BA2ACC2FF8E6}</ProjectGuid>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Import Project="../openfst.props" />
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <ItemGroup>
+    <ClCompile Include="*.cc" />
+    <ClInclude Include="..\include\fst\script\*.h" />
+  </ItemGroup>
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+  <Import Project="../openfst.targets" />
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+</Project>

--- a/src/script/libfstscript.vcxproj.filters
+++ b/src/script/libfstscript.vcxproj.filters
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
@jtrmal, if you have interest and some time, please look at this; wondering what do you think about this script. If you are busy, I can just merge that. And there is no rush indeed.

Basically, I refactored the projects by separating a common set of `.props` and `.targets` files, and added a couple hacks to make the single `bin.vcxproj` generate all executables. The `src/openfst.user.props` file is included for user's modification, and contains a bit of instruction. I placed it into a solution folder with quite a visible name. Perhaps I'll add a readme file with these later.

The semi-breaking change is I am targeting the VS 2017 (v141) compiler by default.

~~The release build uses fast-build whole program optimization, and requires 7GB of free space for cached linker files~~ (the .exe files are less than 1MB each on average, this is only for intermediate files). ~~I'll see if I can improve that, but it does not seem a big deal these days.~~ The build takes quite 20 minutes on my aging 2-core i5 laptop, but under 3 minutes on the fast 8-core workstation.

EDIT: I just pushed a change to use non-incremental LTCG, which cut disk use by 5.5GB.

I think I'll also upload the set of binaries to GitHub as a "release", after I add projects for extensions.