### PR TITLE
Fix handling of newlines on stdout/stdin on windows (Fixes #20)

### DIFF
--- a/src/include/fst/compact-fst.h
+++ b/src/include/fst/compact-fst.h
@@ -1159,6 +1159,7 @@ bool CompactFst<A, ArcCompactor, Unsigned, CompactStore, CacheStore>::WriteFst(
   using Arc = A;
   using Weight = typename A::Weight;
   using Element = typename ArcCompactor::Element;
+  CheckBinaryStdout(strm);
   const auto file_version =
       opts.align ? Impl::kAlignedFileVersion : Impl::kFileVersion;
   size_t num_arcs = -1;

--- a/src/include/fst/const-fst.h
+++ b/src/include/fst/const-fst.h
@@ -191,6 +191,7 @@ ConstFstImpl<Arc, Unsigned>::ConstFstImpl(const Fst<Arc> &fst)
 template <class Arc, class Unsigned>
 ConstFstImpl<Arc, Unsigned> *ConstFstImpl<Arc, Unsigned>::Read(
     std::istream &strm, const FstReadOptions &opts) {
+  CheckBinaryStdin(strm);
   using ConstState = typename ConstFstImpl<Arc, Unsigned>::ConstState;
   std::unique_ptr<ConstFstImpl<Arc, Unsigned>> impl(
       new ConstFstImpl<Arc, Unsigned>());
@@ -327,6 +328,7 @@ template <class Arc, class Unsigned>
 template <class FST>
 bool ConstFst<Arc, Unsigned>::WriteFst(const FST &fst, std::ostream &strm,
                                        const FstWriteOptions &opts) {
+  CheckBinaryStdout(strm);
   const auto file_version =
       opts.align ? internal::ConstFstImpl<Arc, Unsigned>::kAlignedFileVersion
                  : internal::ConstFstImpl<Arc, Unsigned>::kFileVersion;

--- a/src/include/fst/fst.h
+++ b/src/include/fst/fst.h
@@ -232,6 +232,7 @@ class Fst {
 
   // Reads an FST from an input stream; returns nullptr on error.
   static Fst<Arc> *Read(std::istream &strm, const FstReadOptions &opts) {
+    CheckBinaryStdin(strm);
     FstReadOptions ropts(opts);
     FstHeader hdr;
     if (ropts.header) {
@@ -262,6 +263,7 @@ class Fst {
       }
       return Read(strm, FstReadOptions(filename));
     } else {
+      PrepareBinaryStdin();
       return Read(std::cin, FstReadOptions("standard input"));
     }
   }

--- a/src/include/fst/mutable-fst.h
+++ b/src/include/fst/mutable-fst.h
@@ -101,6 +101,7 @@ class MutableFst : public ExpandedFst<A> {
 
   // Reads a MutableFst from an input stream, returning nullptr on error.
   static MutableFst<Arc> *Read(std::istream &strm, const FstReadOptions &opts) {
+    CheckBinaryStdin(strm);
     FstReadOptions ropts(opts);
     FstHeader hdr;
     if (ropts.header) {
@@ -141,6 +142,7 @@ class MutableFst : public ExpandedFst<A> {
         }
         return Read(strm, FstReadOptions(filename));
       } else {
+        PrepareBinaryStdin();
         return Read(std::cin, FstReadOptions("standard input"));
       }
     } else {  // Converts to 'convert_type' if not mutable.

--- a/src/include/fst/util.h
+++ b/src/include/fst/util.h
@@ -19,6 +19,11 @@
 #include <utility>
 #include <vector>
 
+#ifdef _WIN32
+  #include <io.h>
+  #include <fcntl.h>
+#endif
+
 #include <fst/compat.h>
 #include <fst/types.h>
 #include <fst/log.h>
@@ -394,6 +399,36 @@ class CompactSet {
 
   void operator=(const CompactSet &) = delete;
 };
+
+// Utilities for handling Windows newline conversion.
+
+inline void PrepareBinaryStdout() {
+  #ifdef _WIN32
+    _setmode(_fileno(stdout), O_BINARY);
+  #endif
+}
+
+inline void CheckBinaryStdout(std::ostream &strm) {
+  #ifdef _WIN32
+    if (strm.rdbuf() == std::cout.rdbuf()) {
+      _setmode(_fileno(stdout), O_BINARY);
+    }
+  #endif
+}
+
+inline void PrepareBinaryStdin() {
+  #ifdef _WIN32
+    _setmode(_fileno(stdin), O_BINARY);
+  #endif
+}
+
+inline void CheckBinaryStdin(std::istream &strm) {
+  #ifdef _WIN32
+    if (strm.rdbuf() == std::cin.rdbuf()) {
+      _setmode(_fileno(stdin), O_BINARY);
+    }
+  #endif
+}
 
 }  // namespace fst
 

--- a/src/include/fst/vector-fst.h
+++ b/src/include/fst/vector-fst.h
@@ -444,6 +444,7 @@ VectorFstImpl<S>::VectorFstImpl(const Fst<Arc> &fst) {
 template <class S>
 VectorFstImpl<S> *VectorFstImpl<S>::Read(std::istream &strm,
                                          const FstReadOptions &opts) {
+  CheckBinaryStdin(strm);
   std::unique_ptr<VectorFstImpl<S>> impl(new VectorFstImpl());
   FstHeader hdr;
   if (!impl->ReadHeader(strm, opts, kMinFileVersion, &hdr)) return nullptr;
@@ -601,6 +602,7 @@ template <class Arc, class State>
 template <class FST>
 bool VectorFst<Arc, State>::WriteFst(const FST &fst, std::ostream &strm,
                                      const FstWriteOptions &opts) {
+  CheckBinaryStdout(strm);
   static constexpr int file_version = 2;
   bool update_header = true;
   FstHeader hdr;

--- a/src/script/fst-class.cc
+++ b/src/script/fst-class.cc
@@ -82,6 +82,7 @@ FstClass *FstClass::Read(const string &fname) {
     std::ifstream istrm(fname, std::ios_base::in | std::ios_base::binary);
     return ReadFstClass<FstClass>(istrm, fname);
   } else {
+    PrepareBinaryStdin();
     return ReadFstClass<FstClass>(std::cin, "standard input");
   }
 }


### PR DESCRIPTION
I am unsure of the best placement and style, so I am happy to modify to what you want. I certainly may not have covered all cases, but it's been working great for me for months. I haven't tested it on other OSs, though I don't see why it would cause problems.