### PR TITLE
C++20 compatibility: Use std::allocator_traits instead of direct members of std::allocator

### DIFF
--- a/src/include/fst/cache.h
+++ b/src/include/fst/cache.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <functional>
 #include <list>
+#include <memory>
 #include <vector>
 
 #include <fst/flags.h>
@@ -70,7 +71,7 @@ class CacheState {
 
   using ArcAllocator = M;
   using StateAllocator =
-      typename ArcAllocator::template rebind<CacheState<A, M>>::other;
+      typename std::allocator_traits<ArcAllocator>::template rebind_alloc<CacheState<A, M>>;
 
   // Provides STL allocator for arcs.
   explicit CacheState(const ArcAllocator &alloc)

--- a/src/include/fst/vector-fst.h
+++ b/src/include/fst/vector-fst.h
@@ -6,6 +6,7 @@
 #ifndef FST_VECTOR_FST_H_
 #define FST_VECTOR_FST_H_
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -35,7 +36,7 @@ class VectorState {
   using Weight = typename Arc::Weight;
   using ArcAllocator = M;
   using StateAllocator =
-      typename ArcAllocator::template rebind<VectorState<Arc, M>>::other;
+      typename std::allocator_traits<ArcAllocator>::template rebind_alloc<VectorState<Arc, M>>;
 
   // Provide STL allocator for arcs.
   explicit VectorState(const ArcAllocator &alloc)


### PR DESCRIPTION
Usage of direct members of std::allocator got deprecated in C++17 and
removed in C++20. The preferred usage is through std::allocator_traits.