### PR TITLE
Add CI test for Windows with GitHub actions

### DIFF
--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - master
+      - alpha
+      - preflight
 
   pull_request:
     branches:
       - master
+      - alpha
+      - preflight
 
   workflow_dispatch:
 
@@ -43,7 +47,7 @@ jobs:
 
           mkdir build
           cd build
-          cmake -A x64 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
+          cmake -G Ninja -A x64 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
 
       - name: Build openfst for Windows x64
         shell: bash

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -35,13 +35,13 @@ jobs:
           fetch-depth: 0
 
       - name: CMake version
-        shell: cmd
+        shell: bash
         run: |
           cmake --version
           cmake --help
 
       - name: Configure CMake
-        shell: cmd
+        shell: bash
         run: |
           cmake --version
 
@@ -50,7 +50,7 @@ jobs:
           cmake -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
 
       - name: Build openfst for Windows x64
-        shell: cmd
+        shell: bash
         run: |
           cd build
           cmake --build . --config Release -- -m:2

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -35,22 +35,22 @@ jobs:
           fetch-depth: 0
 
       - name: CMake version
-        shell: bash
+        shell: cmd
         run: |
           cmake --version
           cmake --help
 
       - name: Configure CMake
-        shell: bash
+        shell: cmd
         run: |
           cmake --version
 
           mkdir build
           cd build
-          cmake -A x64 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
+          cmake -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
 
       - name: Build openfst for Windows x64
-        shell: bash
+        shell: cmd
         run: |
           cd build
           cmake --build . --config Release -- -m:2

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -1,0 +1,49 @@
+name: windows-x64
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+  workflow_dispatch:
+
+concurrency:
+  group: windows-x64-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows_x64:
+    name: Windows x64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build_type: [Release, Debug]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake --version
+
+          mkdir build
+          cd build
+          cmake -A x64 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
+
+      - name: Build openfst for Windows x64
+        shell: bash
+        run: |
+          cd build
+          cmake --build . --config Release -- -m:2
+          cmake --build . --config Release --target install -- -m:2
+
+          ls -lh ./bin/Release/sherpa-onnx.exe

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -47,7 +47,7 @@ jobs:
 
           mkdir build
           cd build
-          cmake -G Ninja -A x64 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
+          cmake -A x64 -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
 
       - name: Build openfst for Windows x64
         shell: bash

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -45,5 +45,3 @@ jobs:
           cd build
           cmake --build . --config Release -- -m:2
           cmake --build . --config Release --target install -- -m:2
-
-          ls -lh ./bin/Release/sherpa-onnx.exe

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -40,18 +40,23 @@ jobs:
           python-version: "3.8"
 
       - name: Install Python dependencies
-        shell: bash
+        shell: cmd
         run: |
           pip install ninja
 
-      - name: CMake version
+      - name: Show ninja help
         shell: bash
+        run: |
+          ninja --help || true
+
+      - name: CMake version
+        shell: cmd
         run: |
           cmake --version
           cmake --help
 
       - name: Configure CMake
-        shell: bash
+        shell: cmd
         run: |
           cmake --version
 
@@ -60,8 +65,8 @@ jobs:
           cmake -G Ninja -D CMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
 
       - name: Build openfst for Windows x64
-        shell: bash
+        shell: cmd
         run: |
           cd build
-          cmake --build . --config Release -- -m:2
-          cmake --build . --config Release --target install -- -m:2
+          cmake --build . --config Release -- -j 6
+          cmake --build . --config Release --target install -- -j 6

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -34,6 +34,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          pip install ninja
+
       - name: CMake version
         shell: bash
         run: |

--- a/.github/workflows/windows-x64.yaml
+++ b/.github/workflows/windows-x64.yaml
@@ -30,6 +30,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: CMake version
+        shell: bash
+        run: |
+          cmake --version
+          cmake --help
+
       - name: Configure CMake
         shell: bash
         run: |


### PR DESCRIPTION
I find that there is also a PR for GitHub actions about releasing.
https://github.com/kkm000/openfst/pull/46

---

I can help add CI tests for 
 - [ ] other OSes, e.g., macOS and Linux
